### PR TITLE
feat(grants): add pitch pages for Solana ecosystem grants

### DIFF
--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -1,0 +1,401 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import {
+  Shield,
+  Zap,
+  CheckCircle2,
+  ArrowRight,
+  FileText,
+  DollarSign,
+  Users,
+  Github,
+  ExternalLink,
+  Sparkles,
+} from 'lucide-react'
+
+export default function GrantsPage() {
+  return (
+    <>
+      <HeroSection />
+      <GrantCardsSection />
+      <WhyFundSection />
+      <TractionSection />
+      <QuickLinksSection />
+    </>
+  )
+}
+
+function HeroSection() {
+  return (
+    <section className="relative overflow-hidden">
+      {/* Background gradient */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-b from-purple-900/20 via-transparent to-transparent" />
+        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl" />
+        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-pink-500/10 rounded-full blur-3xl" />
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+        <div className="text-center">
+          {/* Badge */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+              <DollarSign className="w-4 h-4" />
+              Grant Applications
+            </span>
+          </motion.div>
+
+          {/* Headline */}
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className="mt-8 text-4xl sm:text-5xl lg:text-6xl font-bold"
+          >
+            Fund the Future of{' '}
+            <span className="bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+              Privacy
+            </span>
+          </motion.h1>
+
+          {/* Subtext */}
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="mt-6 text-lg sm:text-xl text-gray-400 max-w-3xl mx-auto"
+          >
+            SIP Protocol is seeking funding to accelerate privacy adoption on Solana
+            and the broader cross-chain ecosystem. Help us build the privacy layer
+            that Web3 deserves.
+          </motion.p>
+
+          {/* Stats */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            className="mt-10 flex flex-wrap justify-center gap-8"
+          >
+            {[
+              { value: '1,004', label: 'Tests Passing' },
+              { value: 'v0.1.0', label: 'npm Published' },
+              { value: 'M9', label: 'Milestones Complete' },
+              { value: '100%', label: 'Open Source' },
+            ].map((stat) => (
+              <div key={stat.label} className="text-center">
+                <div className="text-2xl sm:text-3xl font-bold text-white">{stat.value}</div>
+                <div className="text-sm text-gray-500">{stat.label}</div>
+              </div>
+            ))}
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function GrantCardsSection() {
+  const grants = [
+    {
+      title: 'Superteam Microgrant',
+      amount: '<$10K',
+      description: 'Community building, developer advocacy, and ecosystem awareness.',
+      href: '/grants/superteam',
+      color: 'from-blue-500 to-cyan-500',
+      borderColor: 'border-blue-500/20 hover:border-blue-500/50',
+      bgColor: 'bg-blue-500/10',
+      textColor: 'text-blue-400',
+      features: [
+        'Community events',
+        'Documentation',
+        'Hackathon participation',
+        'Marketing',
+      ],
+    },
+    {
+      title: 'Solana Foundation',
+      amount: '$100K',
+      description: 'Milestone-based grant for SDK expansion and DeFi integrations.',
+      href: '/grants/solana-foundation',
+      color: 'from-purple-500 to-pink-500',
+      borderColor: 'border-purple-500/20 hover:border-purple-500/50',
+      bgColor: 'bg-purple-500/10',
+      textColor: 'text-purple-400',
+      features: [
+        'Jupiter DEX integration',
+        'Mobile wallet SDK',
+        'Noir circuits mainnet',
+        'Security audit',
+      ],
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="text-3xl sm:text-4xl font-bold"
+          >
+            Active Grant Applications
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-4 text-lg text-gray-400"
+          >
+            View our pitch decks and support our mission
+          </motion.p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2 max-w-4xl mx-auto">
+          {grants.map((grant, index) => (
+            <motion.div
+              key={grant.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+            >
+              <Link
+                href={grant.href}
+                className={`block p-8 rounded-2xl bg-gray-900/50 border ${grant.borderColor} transition-all duration-300 hover:scale-[1.02] group`}
+              >
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6">
+                  <span className={`px-3 py-1 rounded-full text-sm font-medium ${grant.bgColor} ${grant.textColor}`}>
+                    {grant.amount}
+                  </span>
+                  <ArrowRight className="w-5 h-5 text-gray-600 group-hover:text-white group-hover:translate-x-1 transition-all" />
+                </div>
+
+                {/* Title */}
+                <h3 className="text-2xl font-bold mb-3">{grant.title}</h3>
+                <p className="text-gray-400 mb-6">{grant.description}</p>
+
+                {/* Features */}
+                <ul className="space-y-2">
+                  {grant.features.map((feature) => (
+                    <li key={feature} className="flex items-center gap-2 text-sm text-gray-500">
+                      <CheckCircle2 className={`w-4 h-4 ${grant.textColor}`} />
+                      {feature}
+                    </li>
+                  ))}
+                </ul>
+
+                {/* CTA */}
+                <div className={`mt-6 pt-6 border-t border-gray-800 text-center font-medium bg-gradient-to-r ${grant.color} bg-clip-text text-transparent`}>
+                  View Full Pitch →
+                </div>
+              </Link>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function WhyFundSection() {
+  const reasons = [
+    {
+      icon: Shield,
+      title: 'First Stealth Address SDK',
+      description: 'No EIP-5564 implementation exists for Solana. We built it.',
+    },
+    {
+      icon: Zap,
+      title: 'Fills Market Vacuum',
+      description: 'Elusiv sunset, Light Protocol pivoted. We\'re shipping.',
+    },
+    {
+      icon: Users,
+      title: 'Cross-Chain Privacy',
+      description: 'NEAR Intents integration with $6B+ volume. Privacy for all chains.',
+    },
+    {
+      icon: FileText,
+      title: 'Compliance Ready',
+      description: 'Viewing keys enable selective disclosure for institutional use.',
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+          >
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-green-500/10 text-green-400 border border-green-500/20">
+              <Sparkles className="w-4 h-4" />
+              Gap Advantage
+            </span>
+          </motion.div>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Why Fund SIP Protocol?
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {reasons.map((reason, index) => (
+            <motion.div
+              key={reason.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-gray-900/50 border border-gray-800 hover:border-purple-500/50 transition-colors"
+            >
+              <div className="w-12 h-12 rounded-xl bg-purple-500/10 flex items-center justify-center mb-4">
+                <reason.icon className="w-6 h-6 text-purple-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{reason.title}</h3>
+              <p className="text-sm text-gray-400">{reason.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function TractionSection() {
+  const traction = [
+    { metric: '1,004', label: 'Tests Passing', detail: '99.5% pass rate' },
+    { metric: '@sip-protocol/sdk', label: 'npm Package', detail: 'v0.1.0 published' },
+    { metric: 'M1-M9', label: 'Milestones', detail: 'All complete' },
+    { metric: 'Live', label: 'Demo', detail: 'sip-protocol.org' },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="relative rounded-3xl bg-gradient-to-r from-purple-900/30 to-pink-900/30 border border-purple-500/20 overflow-hidden">
+          {/* Background effect */}
+          <div className="absolute inset-0 -z-10">
+            <div className="absolute top-0 right-0 w-64 h-64 bg-purple-500/10 rounded-full blur-3xl" />
+            <div className="absolute bottom-0 left-0 w-64 h-64 bg-pink-500/10 rounded-full blur-3xl" />
+          </div>
+
+          <div className="px-8 py-16 sm:px-16">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl sm:text-4xl font-bold">Proven Traction</h2>
+              <p className="mt-4 text-gray-400">We ship, not vaporware</p>
+            </div>
+
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+              {traction.map((item, index) => (
+                <motion.div
+                  key={item.label}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  whileInView={{ opacity: 1, scale: 1 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: index * 0.1 }}
+                  className="text-center"
+                >
+                  <div className="text-3xl sm:text-4xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+                    {item.metric}
+                  </div>
+                  <div className="mt-2 text-white font-medium">{item.label}</div>
+                  <div className="mt-1 text-sm text-gray-500">{item.detail}</div>
+                </motion.div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function QuickLinksSection() {
+  const links = [
+    {
+      title: 'Live Demo',
+      description: 'Try the privacy toggle',
+      href: '/demo',
+      icon: Zap,
+      external: false,
+    },
+    {
+      title: 'Documentation',
+      description: 'docs.sip-protocol.org',
+      href: 'https://docs.sip-protocol.org',
+      icon: FileText,
+      external: true,
+    },
+    {
+      title: 'GitHub',
+      description: 'View source code',
+      href: 'https://github.com/sip-protocol/sip-protocol',
+      icon: Github,
+      external: true,
+    },
+    {
+      title: 'npm Package',
+      description: '@sip-protocol/sdk',
+      href: 'https://www.npmjs.com/package/@sip-protocol/sdk',
+      icon: ExternalLink,
+      external: true,
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold">Quick Links</h2>
+          <p className="mt-4 text-gray-400">Explore the project</p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 max-w-4xl mx-auto">
+          {links.map((link, index) => (
+            <motion.a
+              key={link.title}
+              href={link.href}
+              target={link.external ? '_blank' : undefined}
+              rel={link.external ? 'noopener noreferrer' : undefined}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="flex items-center gap-4 p-4 rounded-xl bg-gray-900/50 border border-gray-800 hover:border-purple-500/50 transition-colors group"
+            >
+              <div className="w-10 h-10 rounded-lg bg-purple-500/10 flex items-center justify-center">
+                <link.icon className="w-5 h-5 text-purple-400" />
+              </div>
+              <div>
+                <div className="font-medium group-hover:text-purple-400 transition-colors">
+                  {link.title}
+                  {link.external && <ExternalLink className="w-3 h-3 inline ml-1" />}
+                </div>
+                <div className="text-sm text-gray-500">{link.description}</div>
+              </div>
+            </motion.a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/grants/solana-foundation/page.tsx
+++ b/src/app/grants/solana-foundation/page.tsx
@@ -1,0 +1,963 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import { useState } from 'react'
+import {
+  Shield,
+  Zap,
+  CheckCircle2,
+  ArrowLeft,
+  ArrowRight,
+  Users,
+  FileText,
+  Code,
+  AlertTriangle,
+  TrendingUp,
+  Eye,
+  Lock,
+  Github,
+  ExternalLink,
+  DollarSign,
+  Target,
+  Layers,
+  Globe,
+  ChevronDown,
+  Calendar,
+  Award,
+  Search,
+  Smartphone,
+  ShieldCheck,
+} from 'lucide-react'
+
+export default function SolanaFoundationPitchPage() {
+  return (
+    <>
+      <HeroSection />
+      <ProblemSection />
+      <SolutionSection />
+      <WhySolanaSection />
+      <TractionSection />
+      <CompetitorSection />
+      <ArchitectureSection />
+      <MilestonesSection />
+      <BudgetSection />
+      <CTASection />
+    </>
+  )
+}
+
+function HeroSection() {
+  return (
+    <section className="relative overflow-hidden min-h-[90vh] flex items-center">
+      {/* Background gradient */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-b from-purple-900/30 via-transparent to-transparent" />
+        <div className="absolute top-1/4 left-1/4 w-[500px] h-[500px] bg-purple-500/10 rounded-full blur-3xl" />
+        <div className="absolute bottom-1/4 right-1/4 w-[500px] h-[500px] bg-pink-500/10 rounded-full blur-3xl" />
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 w-full">
+        {/* Back link */}
+        <motion.div
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          className="mb-8"
+        >
+          <Link
+            href="/grants"
+            className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Grants
+          </Link>
+        </motion.div>
+
+        <div className="grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            {/* Badge */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+            >
+              <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20">
+                <Award className="w-4 h-4" />
+                Milestone Grant Application
+              </span>
+            </motion.div>
+
+            {/* Headline */}
+            <motion.h1
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="mt-6 text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight"
+            >
+              SIP Protocol
+            </motion.h1>
+
+            {/* Tagline */}
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="mt-4 text-xl sm:text-2xl text-gray-400"
+            >
+              Privacy Layer for Cross-Chain Intents
+            </motion.p>
+
+            {/* Description */}
+            <motion.p
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.3 }}
+              className="mt-6 text-gray-500 max-w-lg"
+            >
+              Application-layer privacy for blockchain intents. Stealth addresses,
+              Pedersen commitments, and viewing keys for institutional compliance.
+            </motion.p>
+
+            {/* Amount */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.4 }}
+              className="mt-8 inline-flex items-center gap-4 px-6 py-4 rounded-2xl bg-purple-500/10 border border-purple-500/20"
+            >
+              <div>
+                <div className="text-sm text-gray-400">Requesting</div>
+                <div className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+                  $100,000
+                </div>
+              </div>
+              <div className="h-12 w-px bg-purple-500/20" />
+              <div>
+                <div className="text-sm text-gray-400">Timeline</div>
+                <div className="text-xl font-semibold text-white">5 Months</div>
+              </div>
+            </motion.div>
+
+            {/* CTAs */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.5 }}
+              className="mt-8 flex flex-wrap gap-4"
+            >
+              <a
+                href="/demo"
+                className="px-6 py-3 text-white bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all font-medium"
+              >
+                Try Live Demo
+              </a>
+              <a
+                href="https://github.com/sip-protocol/sip-protocol"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-6 py-3 text-gray-300 border border-gray-700 rounded-lg hover:text-white hover:border-gray-600 transition-all font-medium flex items-center gap-2"
+              >
+                <Github className="w-4 h-4" />
+                View Source
+              </a>
+            </motion.div>
+          </div>
+
+          {/* Stats Card */}
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            className="p-8 rounded-3xl bg-gray-900/50 border border-gray-800"
+          >
+            <h3 className="text-lg font-semibold mb-6 text-gray-400">Key Metrics</h3>
+            <div className="space-y-6">
+              {[
+                { label: 'Tests Passing', value: '1,004', detail: '99.5% pass rate' },
+                { label: 'npm Package', value: 'Published', detail: '@sip-protocol/sdk v0.1.0' },
+                { label: 'Milestones', value: 'M1-M9', detail: 'All complete' },
+                { label: 'Demo', value: 'Live', detail: 'sip-protocol.org' },
+              ].map((item) => (
+                <div key={item.label} className="flex items-center justify-between">
+                  <div>
+                    <div className="text-gray-400">{item.label}</div>
+                    <div className="text-sm text-gray-600">{item.detail}</div>
+                  </div>
+                  <div className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+                    {item.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+
+        {/* Scroll indicator */}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 1 }}
+          className="absolute bottom-8 left-1/2 -translate-x-1/2"
+        >
+          <ChevronDown className="w-6 h-6 text-gray-600 animate-bounce" />
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function ProblemSection() {
+  const problems = [
+    {
+      icon: AlertTriangle,
+      title: 'Privacy Projects Failed',
+      points: [
+        'Elusiv sunset Feb 2024',
+        'Light Protocol pivoted to ZK Compression',
+        'Otter Cash never launched',
+      ],
+    },
+    {
+      icon: Search,
+      title: 'No Stealth Address SDK',
+      points: [
+        'EIP-5564 exists only for Ethereum',
+        'Solana has no equivalent',
+        'Developers have no tools',
+      ],
+    },
+    {
+      icon: Globe,
+      title: 'Cross-Chain Privacy Gap',
+      points: [
+        'NEAR Intents: $6B+ volume',
+        'Zolana bridge: NO privacy',
+        'Wrapped tokens are transparent',
+      ],
+    },
+    {
+      icon: Eye,
+      title: 'Institutional Blockers',
+      points: [
+        'No compliance features',
+        'All-or-nothing privacy',
+        'Regulatory uncertainty',
+      ],
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-red-500/10 text-red-400 border border-red-500/20"
+          >
+            <AlertTriangle className="w-4 h-4" />
+            The Problem
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Privacy on Solana Has a Critical Gap
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {problems.map((problem, index) => (
+            <motion.div
+              key={problem.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-red-950/20 border border-red-500/20"
+            >
+              <div className="w-12 h-12 rounded-xl bg-red-500/10 flex items-center justify-center mb-4">
+                <problem.icon className="w-6 h-6 text-red-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-3">{problem.title}</h3>
+              <ul className="space-y-2">
+                {problem.points.map((point) => (
+                  <li key={point} className="text-sm text-gray-400 flex items-start gap-2">
+                    <span className="text-red-400 mt-1">•</span>
+                    {point}
+                  </li>
+                ))}
+              </ul>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SolutionSection() {
+  const solutions = [
+    {
+      icon: Shield,
+      title: 'Stealth Addresses',
+      description: 'EIP-5564 adapted for Solana. One-time addresses prevent recipient linkability.',
+    },
+    {
+      icon: Lock,
+      title: 'Pedersen Commitments',
+      description: 'Homomorphic commitments hide amounts while enabling mathematical verification.',
+    },
+    {
+      icon: Eye,
+      title: 'Viewing Keys',
+      description: 'Selective disclosure for compliance. Auditors can verify without exposing user data.',
+    },
+    {
+      icon: Layers,
+      title: 'Privacy Levels',
+      description: 'Transparent, Shielded, or Compliant. Users choose their privacy level.',
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-green-500/10 text-green-400 border border-green-500/20"
+          >
+            <CheckCircle2 className="w-4 h-4" />
+            The Solution
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            SIP Protocol: Privacy That Ships
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.2 }}
+            className="mt-4 text-gray-400 max-w-2xl mx-auto"
+          >
+            Application-layer privacy for cross-chain intents. No new consensus layer.
+            Just plug in our SDK and enable privacy.
+          </motion.p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {solutions.map((solution, index) => (
+            <motion.div
+              key={solution.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-gray-900/50 border border-gray-800 hover:border-green-500/50 transition-colors"
+            >
+              <div className="w-12 h-12 rounded-xl bg-green-500/10 flex items-center justify-center mb-4">
+                <solution.icon className="w-6 h-6 text-green-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{solution.title}</h3>
+              <p className="text-sm text-gray-400">{solution.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function WhySolanaSection() {
+  const reasons = [
+    {
+      icon: Zap,
+      title: 'High Throughput',
+      description: 'Privacy operations require compute. Solana handles it at scale.',
+    },
+    {
+      icon: TrendingUp,
+      title: 'Growing DeFi',
+      description: 'Jupiter, Raydium, Meteora. Privacy unlocks institutional capital.',
+    },
+    {
+      icon: Users,
+      title: 'Institutional Interest',
+      description: 'Confidential Balances shows demand. We extend it cross-chain.',
+    },
+    {
+      icon: Globe,
+      title: 'NEAR Bridge',
+      description: 'NEAR Intents brings cross-chain users. Privacy brings them to Solana.',
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20"
+          >
+            <Target className="w-4 h-4" />
+            Why Solana?
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Perfect Fit for Privacy
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {reasons.map((reason, index) => (
+            <motion.div
+              key={reason.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-purple-950/20 border border-purple-500/20"
+            >
+              <div className="w-12 h-12 rounded-xl bg-purple-500/10 flex items-center justify-center mb-4">
+                <reason.icon className="w-6 h-6 text-purple-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{reason.title}</h3>
+              <p className="text-sm text-gray-400">{reason.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function TractionSection() {
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20"
+          >
+            <TrendingUp className="w-4 h-4" />
+            Traction
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Production-Ready, Not Vaporware
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-2">
+          {/* Metrics */}
+          <motion.div
+            initial={{ opacity: 0, x: -20 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            className="p-8 rounded-2xl bg-gray-900/50 border border-gray-800"
+          >
+            <h3 className="text-xl font-semibold mb-6">Key Metrics</h3>
+            <div className="grid grid-cols-2 gap-6">
+              {[
+                { value: '1,004', label: 'Tests Passing' },
+                { value: '99.5%', label: 'Pass Rate' },
+                { value: 'v0.1.0', label: 'npm Published' },
+                { value: 'M9', label: 'Milestones Done' },
+              ].map((metric) => (
+                <div key={metric.label} className="text-center p-4 rounded-xl bg-gray-800/50">
+                  <div className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+                    {metric.value}
+                  </div>
+                  <div className="text-sm text-gray-500 mt-1">{metric.label}</div>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+
+          {/* Features */}
+          <motion.div
+            initial={{ opacity: 0, x: 20 }}
+            whileInView={{ opacity: 1, x: 0 }}
+            viewport={{ once: true }}
+            className="p-8 rounded-2xl bg-gray-900/50 border border-gray-800"
+          >
+            <h3 className="text-xl font-semibold mb-6">What&apos;s Built</h3>
+            <ul className="space-y-3">
+              {[
+                'Stealth addresses (EIP-5564 adapted)',
+                'Pedersen commitments',
+                'Viewing keys for compliance',
+                'NEAR Intents adapter',
+                'Solana wallet adapter',
+                'Zcash RPC client',
+                'Noir ZK circuits (stubs)',
+                'Hardware wallet support',
+                'DAO treasury operations',
+              ].map((feature) => (
+                <li key={feature} className="flex items-center gap-3 text-gray-400">
+                  <CheckCircle2 className="w-5 h-5 text-green-400 flex-shrink-0" />
+                  {feature}
+                </li>
+              ))}
+            </ul>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CompetitorSection() {
+  const competitors = [
+    { name: 'Elusiv', status: 'Sunset', statusColor: 'text-red-400', advantage: 'We\'re shipping' },
+    { name: 'Light Protocol', status: 'Pivoted', statusColor: 'text-yellow-400', advantage: 'We\'re privacy-focused' },
+    { name: 'Arcium', status: 'MPC Infra', statusColor: 'text-blue-400', advantage: 'We\'re application layer' },
+    { name: 'Confidential Balances', status: 'Single-chain', statusColor: 'text-purple-400', advantage: 'We\'re cross-chain' },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-orange-500/10 text-orange-400 border border-orange-500/20"
+          >
+            <Target className="w-4 h-4" />
+            Competitive Landscape
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            We Fill the Gap
+          </motion.h2>
+        </div>
+
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-2xl overflow-hidden border border-gray-800">
+            <table className="w-full">
+              <thead>
+                <tr className="bg-gray-900/50">
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-gray-400">Project</th>
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-gray-400">Status</th>
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-gray-400">SIP Advantage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {competitors.map((comp, index) => (
+                  <motion.tr
+                    key={comp.name}
+                    initial={{ opacity: 0, x: -20 }}
+                    whileInView={{ opacity: 1, x: 0 }}
+                    viewport={{ once: true }}
+                    transition={{ delay: index * 0.1 }}
+                    className="border-t border-gray-800"
+                  >
+                    <td className="px-6 py-4 font-medium">{comp.name}</td>
+                    <td className={`px-6 py-4 ${comp.statusColor}`}>{comp.status}</td>
+                    <td className="px-6 py-4 text-green-400">{comp.advantage}</td>
+                  </motion.tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ArchitectureSection() {
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-cyan-500/10 text-cyan-400 border border-cyan-500/20"
+          >
+            <Layers className="w-4 h-4" />
+            Architecture
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            How It Works
+          </motion.h2>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="max-w-4xl mx-auto"
+        >
+          <div className="p-8 rounded-2xl bg-gray-900/50 border border-gray-800 font-mono text-sm">
+            <div className="text-gray-500 mb-4">{`// Transaction Flow`}</div>
+            <div className="space-y-2">
+              <div className="text-cyan-400">User Intent</div>
+              <div className="text-gray-600 pl-4">↓</div>
+              <div className="p-4 rounded-xl bg-purple-950/30 border border-purple-500/20">
+                <div className="text-purple-400 font-semibold mb-2">PRIVACY LAYER (SIP)</div>
+                <div className="text-gray-400 text-xs space-y-1">
+                  <div>• Stealth Addresses</div>
+                  <div>• Pedersen Commitments</div>
+                  <div>• Viewing Keys</div>
+                  <div>• ZK Proofs</div>
+                </div>
+              </div>
+              <div className="text-gray-600 pl-4">↓</div>
+              <div className="p-4 rounded-xl bg-blue-950/30 border border-blue-500/20">
+                <div className="text-blue-400 font-semibold mb-2">INTENT LAYER (NEAR)</div>
+                <div className="text-gray-400 text-xs space-y-1">
+                  <div>• Cross-chain routing</div>
+                  <div>• Chain signatures</div>
+                </div>
+              </div>
+              <div className="text-gray-600 pl-4">↓</div>
+              <div className="p-4 rounded-xl bg-green-950/30 border border-green-500/20">
+                <div className="text-green-400 font-semibold mb-2">SETTLEMENT</div>
+                <div className="text-gray-400 text-xs">Solana • Ethereum • Bitcoin • ...</div>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function MilestonesSection() {
+  const milestones = [
+    {
+      id: 'M1',
+      title: 'Jupiter DEX Integration',
+      description: 'Private swap routing through Jupiter aggregator',
+      budget: '$25,000',
+      timeline: 'Month 1-2',
+      icon: Zap,
+    },
+    {
+      id: 'M2',
+      title: 'Mobile Wallet SDK',
+      description: 'React Native SDK for iOS/Android wallets',
+      budget: '$20,000',
+      timeline: 'Month 2-3',
+      icon: Smartphone,
+    },
+    {
+      id: 'M3',
+      title: 'Noir Circuits Mainnet',
+      description: 'Deploy ZK circuits to production',
+      budget: '$30,000',
+      timeline: 'Month 3-4',
+      icon: Code,
+    },
+    {
+      id: 'M4',
+      title: 'Developer Docs & Tutorials',
+      description: 'Comprehensive documentation and video tutorials',
+      budget: '$10,000',
+      timeline: 'Month 4',
+      icon: FileText,
+    },
+    {
+      id: 'M5',
+      title: 'Security Audit',
+      description: 'Third-party security audit by reputable firm',
+      budget: '$15,000',
+      timeline: 'Month 5',
+      icon: ShieldCheck,
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-green-500/10 text-green-400 border border-green-500/20"
+          >
+            <Calendar className="w-4 h-4" />
+            Proposed Milestones
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Roadmap to Delivery
+          </motion.h2>
+        </div>
+
+        <div className="max-w-4xl mx-auto space-y-4">
+          {milestones.map((milestone, index) => (
+            <motion.div
+              key={milestone.id}
+              initial={{ opacity: 0, x: -20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-gray-900/50 border border-gray-800 hover:border-green-500/30 transition-colors"
+            >
+              <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+                <div className="flex items-center gap-4 flex-1">
+                  <div className="w-12 h-12 rounded-xl bg-green-500/10 flex items-center justify-center flex-shrink-0">
+                    <milestone.icon className="w-6 h-6 text-green-400" />
+                  </div>
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-mono px-2 py-0.5 rounded bg-gray-800 text-gray-400">
+                        {milestone.id}
+                      </span>
+                      <h3 className="font-semibold">{milestone.title}</h3>
+                    </div>
+                    <p className="text-sm text-gray-400 mt-1">{milestone.description}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-6 sm:flex-shrink-0">
+                  <div className="text-center">
+                    <div className="text-xs text-gray-500">Timeline</div>
+                    <div className="text-sm font-medium">{milestone.timeline}</div>
+                  </div>
+                  <div className="text-center">
+                    <div className="text-xs text-gray-500">Budget</div>
+                    <div className="text-lg font-bold text-green-400">{milestone.budget}</div>
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function BudgetSection() {
+  const budget = [
+    { category: 'Jupiter Integration', amount: 25000, color: 'bg-purple-500' },
+    { category: 'Mobile SDK', amount: 20000, color: 'bg-blue-500' },
+    { category: 'Noir Circuits', amount: 30000, color: 'bg-green-500' },
+    { category: 'Documentation', amount: 10000, color: 'bg-yellow-500' },
+    { category: 'Security Audit', amount: 15000, color: 'bg-red-500' },
+  ]
+
+  const total = budget.reduce((sum, item) => sum + item.amount, 0)
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20"
+          >
+            <DollarSign className="w-4 h-4" />
+            Budget Breakdown
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Total Request: $100,000
+          </motion.h2>
+        </div>
+
+        <div className="max-w-3xl mx-auto">
+          {/* Progress bar visualization */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="mb-8"
+          >
+            <div className="h-8 rounded-full overflow-hidden flex bg-gray-800">
+              {budget.map((item) => (
+                <motion.div
+                  key={item.category}
+                  initial={{ width: 0 }}
+                  whileInView={{ width: `${(item.amount / total) * 100}%` }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.8 }}
+                  className={`h-full ${item.color}`}
+                  title={`${item.category}: $${item.amount.toLocaleString()}`}
+                />
+              ))}
+            </div>
+          </motion.div>
+
+          {/* Legend */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {budget.map((item, index) => (
+              <motion.div
+                key={item.category}
+                initial={{ opacity: 0, y: 10 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: index * 0.1 }}
+                className="flex items-center gap-3 p-3 rounded-xl bg-gray-900/50 border border-gray-800"
+              >
+                <div className={`w-4 h-4 rounded ${item.color}`} />
+                <div className="flex-1">
+                  <div className="text-sm font-medium">{item.category}</div>
+                  <div className="text-xs text-gray-500">{((item.amount / total) * 100).toFixed(0)}%</div>
+                </div>
+                <div className="font-semibold">${item.amount.toLocaleString()}</div>
+              </motion.div>
+            ))}
+          </div>
+
+          {/* Total */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="mt-8 p-6 rounded-2xl bg-gradient-to-r from-purple-900/50 to-pink-900/50 border border-purple-500/20 text-center"
+          >
+            <div className="text-gray-400">Total Grant Request</div>
+            <div className="text-4xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+              $100,000
+            </div>
+            <div className="text-sm text-gray-500 mt-2">Milestone-based payments over 5 months</div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CTASection() {
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="relative rounded-3xl bg-gradient-to-r from-purple-900/50 to-pink-900/50 border border-purple-500/20 overflow-hidden">
+          {/* Background effect */}
+          <div className="absolute inset-0 -z-10">
+            <div className="absolute top-0 right-0 w-96 h-96 bg-purple-500/10 rounded-full blur-3xl" />
+            <div className="absolute bottom-0 left-0 w-96 h-96 bg-pink-500/10 rounded-full blur-3xl" />
+          </div>
+
+          <div className="px-8 py-16 sm:px-16 text-center">
+            <h2 className="text-3xl sm:text-4xl font-bold">Ready to Fund Privacy on Solana?</h2>
+            <p className="mt-4 text-lg text-gray-400 max-w-2xl mx-auto">
+              SIP Protocol fills the gap left by failed privacy projects. We&apos;ve shipped
+              a production-ready SDK. Help us take it to the next level.
+            </p>
+
+            <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+              <a
+                href="/demo"
+                className="px-8 py-3 text-white bg-gradient-to-r from-purple-500 to-pink-500 rounded-lg hover:from-purple-600 hover:to-pink-600 transition-all font-medium"
+              >
+                Try Live Demo
+              </a>
+              <a
+                href="https://docs.sip-protocol.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-8 py-3 text-gray-300 border border-gray-600 rounded-lg hover:text-white hover:border-gray-500 transition-all font-medium flex items-center gap-2"
+              >
+                <FileText className="w-4 h-4" />
+                Documentation
+              </a>
+              <a
+                href="https://github.com/sip-protocol/sip-protocol"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-8 py-3 text-gray-300 border border-gray-600 rounded-lg hover:text-white hover:border-gray-500 transition-all font-medium flex items-center gap-2"
+              >
+                <Github className="w-4 h-4" />
+                View Code
+              </a>
+            </div>
+
+            {/* Quick stats */}
+            <div className="mt-12 pt-8 border-t border-purple-500/20">
+              <div className="flex flex-wrap justify-center gap-8">
+                {[
+                  { value: '1,004', label: 'Tests' },
+                  { value: 'Published', label: 'npm' },
+                  { value: 'Live', label: 'Demo' },
+                  { value: 'MIT', label: 'License' },
+                ].map((stat) => (
+                  <div key={stat.label} className="text-center">
+                    <div className="text-xl font-bold text-white">{stat.value}</div>
+                    <div className="text-sm text-gray-500">{stat.label}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Links */}
+            <div className="mt-8 flex flex-wrap justify-center gap-6 text-sm text-gray-400">
+              <a href="https://sip-protocol.org" className="hover:text-white transition-colors flex items-center gap-1">
+                <ExternalLink className="w-3 h-3" />
+                sip-protocol.org
+              </a>
+              <a href="https://docs.sip-protocol.org" className="hover:text-white transition-colors flex items-center gap-1">
+                <ExternalLink className="w-3 h-3" />
+                docs.sip-protocol.org
+              </a>
+              <a href="https://www.npmjs.com/package/@sip-protocol/sdk" className="hover:text-white transition-colors flex items-center gap-1">
+                <ExternalLink className="w-3 h-3" />
+                npm: @sip-protocol/sdk
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/app/grants/superteam/page.tsx
+++ b/src/app/grants/superteam/page.tsx
@@ -1,0 +1,567 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import Link from 'next/link'
+import {
+  Shield,
+  Zap,
+  CheckCircle2,
+  ArrowLeft,
+  Users,
+  FileText,
+  Megaphone,
+  Code,
+  Trophy,
+  AlertTriangle,
+  TrendingUp,
+  Eye,
+  Lock,
+  Github,
+  ExternalLink,
+  DollarSign,
+} from 'lucide-react'
+
+export default function SuperteamPitchPage() {
+  return (
+    <>
+      <HeroSection />
+      <ProblemSection />
+      <SolutionSection />
+      <TractionSection />
+      <BudgetSection />
+      <TeamSection />
+      <CTASection />
+    </>
+  )
+}
+
+function HeroSection() {
+  return (
+    <section className="relative overflow-hidden">
+      {/* Background gradient */}
+      <div className="absolute inset-0 -z-10">
+        <div className="absolute inset-0 bg-gradient-to-b from-blue-900/20 via-transparent to-transparent" />
+        <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl" />
+        <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-cyan-500/10 rounded-full blur-3xl" />
+      </div>
+
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
+        {/* Back link */}
+        <motion.div
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          className="mb-8"
+        >
+          <Link
+            href="/grants"
+            className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Grants
+          </Link>
+        </motion.div>
+
+        <div className="text-center">
+          {/* Badge */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+          >
+            <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20">
+              <DollarSign className="w-4 h-4" />
+              Microgrant Application
+            </span>
+          </motion.div>
+
+          {/* Logo/Brand */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className="mt-8 flex items-center justify-center gap-4"
+          >
+            <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center">
+              <Shield className="w-8 h-8 text-white" />
+            </div>
+          </motion.div>
+
+          {/* Headline */}
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="mt-6 text-4xl sm:text-5xl lg:text-6xl font-bold"
+          >
+            SIP Protocol
+          </motion.h1>
+
+          {/* Tagline */}
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.3 }}
+            className="mt-4 text-xl sm:text-2xl text-gray-400"
+          >
+            Privacy Layer for Cross-Chain Intents
+          </motion.p>
+
+          {/* Amount */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.4 }}
+            className="mt-8 inline-flex items-center gap-3 px-6 py-3 rounded-2xl bg-blue-500/10 border border-blue-500/20"
+          >
+            <span className="text-gray-400">Requesting</span>
+            <span className="text-3xl font-bold bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">
+              $8,000
+            </span>
+          </motion.div>
+
+          {/* Quick Links */}
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.5 }}
+            className="mt-8 flex flex-wrap justify-center gap-4"
+          >
+            <a
+              href="/demo"
+              className="px-5 py-2.5 text-white bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all font-medium"
+            >
+              Try Live Demo
+            </a>
+            <a
+              href="https://docs.sip-protocol.org"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-5 py-2.5 text-gray-300 border border-gray-700 rounded-lg hover:text-white hover:border-gray-600 transition-all font-medium"
+            >
+              Read Docs
+            </a>
+            <a
+              href="https://github.com/sip-protocol/sip-protocol"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-5 py-2.5 text-gray-300 border border-gray-700 rounded-lg hover:text-white hover:border-gray-600 transition-all font-medium flex items-center gap-2"
+            >
+              <Github className="w-4 h-4" />
+              GitHub
+            </a>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ProblemSection() {
+  const problems = [
+    {
+      icon: AlertTriangle,
+      title: 'No Stealth Address SDK',
+      description: 'EIP-5564 exists for Ethereum, but Solana has no equivalent. Privacy-conscious users have no tools.',
+    },
+    {
+      icon: TrendingUp,
+      title: 'Privacy Projects Failed',
+      description: 'Elusiv sunset in Feb 2024. Light Protocol pivoted to ZK Compression. The market has a vacuum.',
+    },
+    {
+      icon: Eye,
+      title: 'Cross-Chain Privacy Gap',
+      description: 'NEAR Intents processes $6B+ but Zolana bridge offers NO privacy - just wrapped tokens.',
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-red-500/10 text-red-400 border border-red-500/20"
+          >
+            <AlertTriangle className="w-4 h-4" />
+            The Problem
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            Privacy on Solana is Broken
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-3">
+          {problems.map((problem, index) => (
+            <motion.div
+              key={problem.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-red-950/20 border border-red-500/20"
+            >
+              <div className="w-12 h-12 rounded-xl bg-red-500/10 flex items-center justify-center mb-4">
+                <problem.icon className="w-6 h-6 text-red-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{problem.title}</h3>
+              <p className="text-sm text-gray-400">{problem.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SolutionSection() {
+  const solutions = [
+    {
+      icon: Shield,
+      title: 'Stealth Addresses',
+      description: 'First EIP-5564 implementation adapted for Solana. One-time recipient addresses prevent linkability.',
+    },
+    {
+      icon: Lock,
+      title: 'Pedersen Commitments',
+      description: 'Homomorphic commitments hide transaction amounts while enabling verification.',
+    },
+    {
+      icon: Eye,
+      title: 'Viewing Keys',
+      description: 'Selective disclosure for compliance. Institutions can audit without compromising user privacy.',
+    },
+    {
+      icon: Zap,
+      title: 'NEAR Intents Integration',
+      description: 'Cross-chain privacy via NEAR Intents. Privacy layer for the $6B+ ecosystem.',
+    },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-green-500/10 text-green-400 border border-green-500/20"
+          >
+            <CheckCircle2 className="w-4 h-4" />
+            The Solution
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            SIP Protocol Delivers
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          {solutions.map((solution, index) => (
+            <motion.div
+              key={solution.title}
+              initial={{ opacity: 0, y: 20 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-gray-900/50 border border-gray-800 hover:border-green-500/50 transition-colors"
+            >
+              <div className="w-12 h-12 rounded-xl bg-green-500/10 flex items-center justify-center mb-4">
+                <solution.icon className="w-6 h-6 text-green-400" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">{solution.title}</h3>
+              <p className="text-sm text-gray-400">{solution.description}</p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function TractionSection() {
+  const metrics = [
+    { value: '1,004', label: 'Tests Passing', detail: '99.5% pass rate' },
+    { value: 'Published', label: 'npm Package', detail: '@sip-protocol/sdk v0.1.0' },
+    { value: 'Live', label: 'Demo Deployed', detail: 'sip-protocol.org' },
+    { value: 'M9', label: 'Milestones Done', detail: 'Production ready' },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-purple-500/10 text-purple-400 border border-purple-500/20"
+          >
+            <TrendingUp className="w-4 h-4" />
+            Traction
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            We Ship, Not Vaporware
+          </motion.h2>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {metrics.map((metric, index) => (
+            <motion.div
+              key={metric.label}
+              initial={{ opacity: 0, scale: 0.9 }}
+              whileInView={{ opacity: 1, scale: 1 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-6 rounded-2xl bg-gradient-to-br from-purple-900/30 to-pink-900/30 border border-purple-500/20 text-center"
+            >
+              <div className="text-3xl font-bold bg-gradient-to-r from-purple-400 to-pink-500 bg-clip-text text-transparent">
+                {metric.value}
+              </div>
+              <div className="mt-2 text-white font-medium">{metric.label}</div>
+              <div className="mt-1 text-sm text-gray-500">{metric.detail}</div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Code example */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="mt-12 p-6 rounded-2xl bg-gray-900/80 border border-gray-800"
+        >
+          <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
+            <Code className="w-4 h-4" />
+            Install in seconds
+          </div>
+          <code className="text-green-400 font-mono">npm install @sip-protocol/sdk</code>
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function BudgetSection() {
+  const budget = [
+    { category: 'Community Building', amount: '$3,000', percent: 37.5, icon: Users },
+    { category: 'Documentation', amount: '$2,000', percent: 25, icon: FileText },
+    { category: 'Hackathon Participation', amount: '$2,000', percent: 25, icon: Trophy },
+    { category: 'Marketing & Awareness', amount: '$1,000', percent: 12.5, icon: Megaphone },
+  ]
+
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.span
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-sm font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20"
+          >
+            <DollarSign className="w-4 h-4" />
+            Budget Breakdown
+          </motion.span>
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-6 text-3xl sm:text-4xl font-bold"
+          >
+            The Ask: $8,000
+          </motion.h2>
+        </div>
+
+        <div className="max-w-2xl mx-auto space-y-4">
+          {budget.map((item, index) => (
+            <motion.div
+              key={item.category}
+              initial={{ opacity: 0, x: -20 }}
+              whileInView={{ opacity: 1, x: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: index * 0.1 }}
+              className="p-4 rounded-xl bg-gray-900/50 border border-gray-800"
+            >
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-blue-500/10 flex items-center justify-center">
+                    <item.icon className="w-5 h-5 text-blue-400" />
+                  </div>
+                  <span className="font-medium">{item.category}</span>
+                </div>
+                <span className="text-blue-400 font-semibold">{item.amount}</span>
+              </div>
+              {/* Progress bar */}
+              <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
+                <motion.div
+                  initial={{ width: 0 }}
+                  whileInView={{ width: `${item.percent}%` }}
+                  viewport={{ once: true }}
+                  transition={{ duration: 0.8, delay: index * 0.1 }}
+                  className="h-full bg-gradient-to-r from-blue-500 to-cyan-500 rounded-full"
+                />
+              </div>
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Total */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="mt-8 text-center"
+        >
+          <div className="inline-flex items-center gap-4 px-8 py-4 rounded-2xl bg-blue-500/10 border border-blue-500/20">
+            <span className="text-gray-400">Total Request</span>
+            <span className="text-3xl font-bold text-white">$8,000</span>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function TeamSection() {
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <motion.h2
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="text-3xl sm:text-4xl font-bold"
+          >
+            Built by Developers, for Developers
+          </motion.h2>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.1 }}
+            className="mt-4 text-gray-400"
+          >
+            Passionate about privacy and open source
+          </motion.p>
+        </div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          className="max-w-xl mx-auto p-8 rounded-2xl bg-gray-900/50 border border-gray-800 text-center"
+        >
+          <div className="w-20 h-20 mx-auto rounded-full bg-gradient-to-br from-purple-500 to-pink-500 flex items-center justify-center mb-4">
+            <Users className="w-10 h-10 text-white" />
+          </div>
+          <h3 className="text-xl font-semibold">SIP Protocol Team</h3>
+          <p className="mt-2 text-gray-400">
+            Full-stack developers with experience in cryptography, blockchain, and privacy-preserving technologies.
+          </p>
+          <div className="mt-6 flex justify-center gap-4">
+            <a
+              href="https://github.com/sip-protocol"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="p-2 rounded-lg bg-gray-800 hover:bg-gray-700 transition-colors"
+            >
+              <Github className="w-5 h-5" />
+            </a>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  )
+}
+
+function CTASection() {
+  return (
+    <section className="py-24 border-t border-gray-800/50">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="relative rounded-3xl bg-gradient-to-r from-blue-900/50 to-cyan-900/50 border border-blue-500/20 overflow-hidden">
+          {/* Background effect */}
+          <div className="absolute inset-0 -z-10">
+            <div className="absolute top-0 right-0 w-64 h-64 bg-blue-500/10 rounded-full blur-3xl" />
+            <div className="absolute bottom-0 left-0 w-64 h-64 bg-cyan-500/10 rounded-full blur-3xl" />
+          </div>
+
+          <div className="px-8 py-16 sm:px-16 text-center">
+            <h2 className="text-3xl sm:text-4xl font-bold">Ready to Support Privacy?</h2>
+            <p className="mt-4 text-lg text-gray-400 max-w-2xl mx-auto">
+              Help us build the privacy layer that Solana deserves. Your support accelerates
+              adoption and brings privacy to millions of users.
+            </p>
+
+            <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
+              <a
+                href="/demo"
+                className="px-8 py-3 text-white bg-gradient-to-r from-blue-500 to-cyan-500 rounded-lg hover:from-blue-600 hover:to-cyan-600 transition-all font-medium"
+              >
+                Try Live Demo
+              </a>
+              <a
+                href="https://docs.sip-protocol.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-8 py-3 text-gray-300 border border-gray-600 rounded-lg hover:text-white hover:border-gray-500 transition-all font-medium flex items-center gap-2"
+              >
+                <FileText className="w-4 h-4" />
+                Documentation
+              </a>
+              <a
+                href="https://github.com/sip-protocol/sip-protocol"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-8 py-3 text-gray-300 border border-gray-600 rounded-lg hover:text-white hover:border-gray-500 transition-all font-medium flex items-center gap-2"
+              >
+                <Github className="w-4 h-4" />
+                View Code
+              </a>
+            </div>
+
+            {/* Links */}
+            <div className="mt-10 pt-8 border-t border-blue-500/20">
+              <div className="flex flex-wrap justify-center gap-6 text-sm text-gray-400">
+                <a href="https://sip-protocol.org" className="hover:text-white transition-colors flex items-center gap-1">
+                  <ExternalLink className="w-3 h-3" />
+                  sip-protocol.org
+                </a>
+                <a href="https://docs.sip-protocol.org" className="hover:text-white transition-colors flex items-center gap-1">
+                  <ExternalLink className="w-3 h-3" />
+                  docs.sip-protocol.org
+                </a>
+                <a href="https://www.npmjs.com/package/@sip-protocol/sdk" className="hover:text-white transition-colors flex items-center gap-1">
+                  <ExternalLink className="w-3 h-3" />
+                  npm: @sip-protocol/sdk
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary

Add dedicated grant pitch pages for Solana Foundation and Superteam microgrant applications.

### Pages Added

| Route | Purpose |
|-------|---------|
| `/grants` | Landing page with overview and links |
| `/grants/superteam` | Superteam microgrant pitch ($8K) |
| `/grants/solana-foundation` | SF milestone grant pitch ($100K) |

### Features

- Responsive design matching existing site styling
- Framer Motion animations throughout
- Problem → Solution → Traction → Budget flow
- Interactive milestone visualization (SF pitch)
- Budget breakdown with visual progress bars
- Direct links to demo, docs, and GitHub

### Screenshots

Pages follow existing site patterns with:
- Hero sections with gradient backgrounds
- Stats cards with animated counters
- Competitive landscape comparison table
- Architecture diagram (SF pitch)
- Call-to-action sections

### Test Plan

- [x] TypeScript type checking passes
- [x] ESLint passes
- [x] All 121 tests pass
- [ ] Manual testing of all 3 routes
- [ ] Mobile responsiveness check
- [ ] Dark mode verification

### Related Issues

Closes sip-protocol/sip-protocol#86 (Superteam pitch page spec)
Closes sip-protocol/sip-protocol#87 (SF pitch page spec)
Closes sip-protocol/sip-protocol#90 (Landing page spec)
Closes #19 (Implementation tracking)

Part of: sip-protocol/sip-protocol#85 (Epic: Solana Grants Pursuit)