### PR TITLE
fix(docker): bump to node:22-alpine + pin pnpm@10.33.2 (preemptive)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@
 # ============================================
 # Stage 1: Dependencies
 # ============================================
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 
 # Copy package files
 COPY package.json pnpm-lock.yaml* ./
@@ -19,11 +19,11 @@ RUN pnpm install --frozen-lockfile
 # ============================================
 # Stage 2: Builder
 # ============================================
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.2 --activate
 
 # Copy dependencies from deps stage
 COPY --from=deps /app/node_modules ./node_modules
@@ -47,7 +47,7 @@ RUN pnpm build
 # ============================================
 # Stage 3: Runner (Production)
 # ============================================
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary
Preemptive Dockerfile fix to avoid a deploy failure mode that's already broken sip-app.

sip-website hasn't been deployed since 2026-04-08, so the issue hasn't surfaced yet. But the next deploy attempt would fail at \`pnpm install --frozen-lockfile\` with the same pair of errors that broke sip-app this week:

\`\`\`
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
(pnpm v11 requires Node 22.5+'s built-in sqlite; node:20-alpine doesn't have it)
\`\`\`

\`\`\`
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
(pnpm v11's strict override-hash validation rejects lockfiles generated by pnpm v10)
\`\`\`

## Fix
- \`node:20-alpine\` → \`node:22-alpine\` (all 3 stages)
- \`corepack prepare pnpm@latest --activate\` → \`pnpm@10.33.2\` (both stages)

5-line change. Matches the combo shipped to sip-app via sip-protocol/sip-app#271 + #272. Same combo as local dev environment.

## Test plan
- [ ] CI \`build-and-push\` succeeds with the bumped image
- [ ] No regression in served pages (Stage 3 = runner is identical other than the base image bump)

## Context
- Same root cause as sip-app's broken deploys this week
- Filed to avoid being surprised when the next sip-website deploy is needed (could be during a launch or critical fix)