### PR TITLE
chore: support Vercel deployment (apex migration)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,22 @@
+# Vercel CLI ignores .gitignore, so mirror the build-artifact + secret exclusions here.
+# Vercel rebuilds from source — never upload these.
+.next
+out
+node_modules
+.vercel
+
+# Local env files (never upload secrets; Vercel env is set in project settings)
+.env
+.env.local
+.env*.local
+
+# Tests / reports / caches
+coverage
+test-results
+playwright-report
+playwright/.cache
+
+# Misc
+.git
+*.log
+.DS_Store

--- a/next.config.js
+++ b/next.config.js
@@ -11,7 +11,8 @@ try {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  // On Vercel use the platform's native output; keep 'standalone' for the VPS Docker rollback image.
+  output: process.env.VERCEL ? undefined : 'standalone',
   eslint: {
     // Use flat config file
     ignoreDuringBuilds: false,
@@ -29,8 +30,12 @@ const nextConfig = {
     ],
   },
   env: {
-    NEXT_PUBLIC_GIT_COMMIT: process.env.GIT_COMMIT || 'dev',
-    NEXT_PUBLIC_GIT_BRANCH: process.env.GIT_BRANCH || 'local',
+    // The VPS Docker image bakes GIT_COMMIT/GIT_BRANCH via build-args; on Vercel those are absent,
+    // so fall back to Vercel's built-in git vars to keep the footer build link resolving to a real commit.
+    NEXT_PUBLIC_GIT_COMMIT:
+      process.env.GIT_COMMIT ||
+      (process.env.VERCEL_GIT_COMMIT_SHA ? process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7) : 'dev'),
+    NEXT_PUBLIC_GIT_BRANCH: process.env.GIT_BRANCH || process.env.VERCEL_GIT_COMMIT_REF || 'local',
   },
   async redirects() {
     return [

--- a/src/app/api/zcash/route.ts
+++ b/src/app/api/zcash/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { ZcashRPCClient } from '@sip-protocol/sdk'
+import type { ZcashRPCClient } from '@sip-protocol/sdk'
 import { zcashRateLimiter, getClientIp } from '@/lib/rate-limiter'
 
 /**
@@ -33,7 +33,7 @@ interface ZcashRPCRequestBody {
 // Lazy-initialized client (created on first request)
 let rpcClient: ZcashRPCClient | null = null
 
-function getClient(): ZcashRPCClient | null {
+async function getClient(): Promise<ZcashRPCClient | null> {
   // Check if already initialized
   if (rpcClient) return rpcClient
 
@@ -45,6 +45,13 @@ function getClient(): ZcashRPCClient | null {
   if (!host || !username || !password) {
     return null
   }
+
+  // Load the SDK lazily, only once Zcash is actually configured. A top-level import pulls in
+  // @sip-protocol/sdk's full module graph (incl. @triton-one/yellowstone-grpc, externalized as
+  // commonjs by next.config.js). Dependency tracing drops that package from packaged builds
+  // (Vercel serverless + Next standalone) → MODULE_NOT_FOUND 500 on every request. Deferring the
+  // import keeps the default (unconfigured) path SDK-free so it returns 200 as intended.
+  const { ZcashRPCClient } = await import('@sip-protocol/sdk')
 
   const port = process.env.ZCASH_RPC_PORT ? parseInt(process.env.ZCASH_RPC_PORT, 10) : undefined
   const testnet = process.env.ZCASH_RPC_TESTNET === 'true'
@@ -85,7 +92,7 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const client = getClient()
+  const client = await getClient()
 
   if (!client) {
     return NextResponse.json({
@@ -138,7 +145,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const client = getClient()
+  const client = await getClient()
 
   if (!client) {
     return NextResponse.json(


### PR DESCRIPTION
Migrates **sip-protocol.org** (apex + www + staging) off VPS reclabs3 → Vercel — the last of the 5 sip-protocol web properties (docs, blog, cdn, sip-app already live on Vercel).

## Changes
- **next.config.js** — `output` is now conditional on `VERCEL`: Vercel uses native output while the VPS Docker image keeps building `standalone` (retained as the rollback target during the 7-day buffer). The git build-tag env falls back to Vercel's `VERCEL_GIT_COMMIT_SHA/REF` so the footer commit link keeps resolving on the new host.
- **.vercelignore** (new) — the Vercel CLI ignores `.gitignore`; this keeps build artifacts and local env files out of CLI uploads.
- **fix(api/zcash)** — lazy-load `@sip-protocol/sdk` inside `getClient()` behind the `ZCASH_RPC_*` check. The eager top-level import pulled the SDK's full module graph incl. `@triton-one/yellowstone-grpc` (externalized as commonjs on the server), which dependency tracing drops from *packaged* builds (Vercel serverless + Next standalone) → `MODULE_NOT_FOUND` 500 on every request. This was a **pre-existing 500 on the VPS too** (`next start` masked it by shipping the full `node_modules`). Now returns the intended `{configured:false}` 200.

## Verification (preview deploy)
- 18 marketing pages → 200; `/pitch-deck` → 308 → `/showcase/zypherpunk-2025` (intended redirect).
- `/api/health` → 200; `/api/zcash` → 200 `{configured:false}` (was 500 on both VPS and Vercel).
- Footer build tag resolves to the real commit; CSP + security headers intact; `NEXT_PUBLIC_REAL_SWAPS=true` parity preserved.
- Both build paths exit 0: `pnpm build` (standalone) and `VERCEL=1 pnpm build` (native).

VPS `sip-website` (port 5000) stays live as instant rollback through the 7-day buffer.