### PR TITLE
chore: gitignore the .vercel directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ playwright/.cache/
 test-results/
 .strategy/
 package-lock.json
+.vercel


### PR DESCRIPTION
Adds `.vercel` to `.gitignore`. The directory is created by `vercel link` (done during the Vercel migration, PR #200) and holds the local project↔Vercel binding (`project.json` with `projectId`/`orgId`). It's machine-local and should never be committed.

One line; no functional change.