### PR TITLE
feat: Discord community link in footer

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -43,8 +43,17 @@ const footerLinks: Record<string, FooterSection> = {
     links: [
       { href: 'https://github.com/sip-protocol/sip-protocol', label: 'GitHub', external: true },
       { href: 'https://x.com/sipprotocol', label: 'Twitter', external: true },
+      { href: 'https://discord.gg/gXRsWkKq9E', label: 'Discord', external: true },
     ],
   },
+}
+
+function DiscordIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M20.317 4.37a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.058a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/>
+    </svg>
+  )
 }
 
 export function Footer() {
@@ -90,6 +99,15 @@ export function Footer() {
                   aria-label="Twitter"
                 >
                   <Twitter className="h-5 w-5" />
+                </a>
+                <a
+                  href="https://discord.gg/gXRsWkKq9E"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-gray-400 hover:text-white transition-colors"
+                  aria-label="Discord"
+                >
+                  <DiscordIcon className="h-5 w-5" />
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Adds the Discord invite (T3 gate A1 — server live: https://discord.gg/gXRsWkKq9E) to the footer community column + social icon row (inline brand SVG; lucide has no Discord glyph).

157 tests pass, typecheck clean.

Spec: sip-protocol `docs/superpowers/specs/2026-06-10-discord-server-design.md`