### PR TITLE
chore(deps): upgrade lucide-react to v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@solana/spl-token": "0.4.14",
     "@solana/web3.js": "^1.98.4",
     "framer-motion": "^12.40.0",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.17.0",
     "near-api-js": "^6.5.1",
     "next": "^15.5.18",
     "react": "^19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,8 +59,8 @@ importers:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       lucide-react:
-        specifier: ^0.562.0
-        version: 0.562.0(react@19.2.7)
+        specifier: ^1.17.0
+        version: 1.18.0(react@19.2.7)
       near-api-js:
         specifier: ^6.5.1
         version: 6.5.1(8006b274b27e59691d62f2814d1c635e)
@@ -4337,8 +4337,8 @@ packages:
   lru_map@0.4.1:
     resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
-  lucide-react@0.562.0:
-    resolution: {integrity: sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==}
+  lucide-react@1.18.0:
+    resolution: {integrity: sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -10889,7 +10889,7 @@ snapshots:
 
   lru_map@0.4.1: {}
 
-  lucide-react@0.562.0(react@19.2.7):
+  lucide-react@1.18.0(react@19.2.7):
     dependencies:
       react: 19.2.7
 

--- a/src/app/about/sections.tsx
+++ b/src/app/about/sections.tsx
@@ -7,13 +7,13 @@ import {
   Zap,
   Target,
   Users,
-  Github,
   ExternalLink,
   Check,
   ArrowRight,
   BookOpen,
   Package
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import Link from 'next/link'
 import { TEST_COUNTS, PROJECT_STATUS } from '@/lib/constants'
 import { FounderProfile } from '@/components/founder-profile'

--- a/src/app/grants/audit-subsidy/content.tsx
+++ b/src/app/grants/audit-subsidy/content.tsx
@@ -20,7 +20,6 @@ import {
   AlertTriangle,
   Eye,
   Lock,
-  Github,
   ExternalLink,
   Target,
   Code,
@@ -31,6 +30,7 @@ import {
   Calendar,
   Award,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION } from '@/lib/constants'
 import { FounderProfile } from '@/components/founder-profile'
 import type { FounderData } from '@/lib/founder-data'

--- a/src/app/grants/page.tsx
+++ b/src/app/grants/page.tsx
@@ -10,10 +10,10 @@ import {
   FileText,
   DollarSign,
   Users,
-  Github,
   ExternalLink,
   Sparkles,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION, ACHIEVEMENTS, PROJECT_STATUS } from '@/lib/constants'
 
 export default function GrantsPage() {

--- a/src/app/grants/solana-foundation/content.tsx
+++ b/src/app/grants/solana-foundation/content.tsx
@@ -19,7 +19,6 @@ import {
   Blocks,
   DollarSign,
   FileText,
-  Github,
   ExternalLink,
   Wallet,
   TrendingUp,
@@ -42,6 +41,7 @@ import {
   Database,
   FileCode,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION } from '@/lib/constants'
 import { VideoDemo } from '@/components/video-demo'
 import { FounderProfile } from '@/components/founder-profile'

--- a/src/app/grants/superteam/content.tsx
+++ b/src/app/grants/superteam/content.tsx
@@ -22,7 +22,6 @@ import {
   TrendingUp,
   Eye,
   Lock,
-  Github,
   ExternalLink,
   DollarSign,
   Target,
@@ -32,6 +31,7 @@ import {
   Sparkles,
   ArrowRight,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION } from '@/lib/constants'
 import { VideoDemo } from '@/components/video-demo'
 import { FounderProfile } from '@/components/founder-profile'

--- a/src/app/license/page.tsx
+++ b/src/app/license/page.tsx
@@ -1,4 +1,5 @@
-import { Scale, Github, ExternalLink } from 'lucide-react'
+import { Scale, ExternalLink } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import Link from 'next/link'
 
 export default function LicensePage() {

--- a/src/app/pitch-deck/content.tsx
+++ b/src/app/pitch-deck/content.tsx
@@ -21,10 +21,10 @@ import {
   Layers,
   Globe,
   FileText,
-  Github,
   ChevronDown,
   ExternalLink
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION, PROJECT_STATUS } from '@/lib/constants'
 import { FounderProfile } from '@/components/founder-profile'
 import { ArchitectureDiagram } from '@/components/architecture-diagram'

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -22,7 +22,6 @@ import {
   Lock,
   Network,
   ArrowRight,
-  Github,
   ExternalLink,
   Sparkles,
   Trophy,
@@ -34,6 +33,7 @@ import {
   Check,
   X,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 
 export default function RoadmapPage() {
   return (

--- a/src/app/showcase/zypherpunk-2025/content.tsx
+++ b/src/app/showcase/zypherpunk-2025/content.tsx
@@ -21,10 +21,10 @@ import {
   Layers,
   Globe,
   FileText,
-  Github,
   ChevronDown,
   ExternalLink
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION, PROJECT_STATUS } from '@/lib/constants'
 import { FounderProfile } from '@/components/founder-profile'
 import { ArchitectureDiagram } from '@/components/architecture-diagram'

--- a/src/components/grants/solana-foundation/hero-section.tsx
+++ b/src/components/grants/solana-foundation/hero-section.tsx
@@ -4,10 +4,10 @@ import { motion } from 'framer-motion'
 import Link from 'next/link'
 import {
   ArrowLeft,
-  Github,
   Globe,
   ChevronDown,
 } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { TEST_COUNTS, SDK_VERSION } from '@/lib/constants'
 
 export function HeroSection() {

--- a/src/components/icons/brand-icons.tsx
+++ b/src/components/icons/brand-icons.tsx
@@ -1,0 +1,46 @@
+import type { SVGProps } from 'react'
+
+/**
+ * Official brand marks, inlined as `currentColor` SVGs.
+ *
+ * lucide-react 1.x removed its deprecated brand icons (`Github`, `Twitter`, …),
+ * so these stand in for them with no extra dependency. They mirror lucide's
+ * call surface: pass `className` (e.g. `h-5 w-5`) to size them, and color is
+ * inherited from the surrounding text color.
+ */
+
+export function Github({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  )
+}
+
+/**
+ * X (formerly Twitter). lucide removed `Twitter`; the site already links to
+ * x.com/sipprotocol, so we use the current X mark rather than the legacy bird.
+ */
+export function XLogo({ className, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      {...props}
+    >
+      <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
+    </svg>
+  )
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import Image from 'next/image'
-import { Github, Twitter, ExternalLink } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
+import { Github, XLogo } from '@/components/icons/brand-icons'
 
 interface FooterLink {
   href: string
@@ -42,7 +43,7 @@ const footerLinks: Record<string, FooterSection> = {
     title: 'Community',
     links: [
       { href: 'https://github.com/sip-protocol/sip-protocol', label: 'GitHub', external: true },
-      { href: 'https://x.com/sipprotocol', label: 'Twitter', external: true },
+      { href: 'https://x.com/sipprotocol', label: 'X', external: true },
       { href: 'https://discord.gg/gXRsWkKq9E', label: 'Discord', external: true },
     ],
   },
@@ -96,9 +97,9 @@ export function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-gray-400 hover:text-white transition-colors"
-                  aria-label="Twitter"
+                  aria-label="X"
                 >
-                  <Twitter className="h-5 w-5" />
+                  <XLogo className="h-5 w-5" />
                 </a>
                 <a
                   href="https://discord.gg/gXRsWkKq9E"

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,7 +5,8 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import Image from 'next/image'
 import dynamic from 'next/dynamic'
-import { Menu, X, Github, ExternalLink } from 'lucide-react'
+import { Menu, X, ExternalLink } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 
 // Dynamic import to avoid SSR issues with SDK's WASM dependencies
 const WalletButton = dynamic(

--- a/src/components/team-section.tsx
+++ b/src/components/team-section.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { Github, ArrowRight } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
+import { Github } from '@/components/icons/brand-icons'
 import { FounderProfile } from '@/components/founder-profile'
 import type { FounderData } from '@/lib/founder-data'
 


### PR DESCRIPTION
Supersedes #211 (Dependabot bump-only, which would have broken the build).

## What
lucide-react 1.x **removes its deprecated brand icons** (`Github`, `Twitter`), so a plain version bump fails to compile. This PR bumps the dep *and* handles the breakage:

- **New module** `src/components/icons/brand-icons.tsx` — inlines the official **GitHub** and **X** marks as `currentColor` SVGs (mirrors lucide's `className` API, **no new dependency**). The GitHub path matches the octocat already used in `technical-deep-dive.tsx`.
- **13 import sites** migrated off the removed lucide exports onto the new module. `<Github />` usages are unchanged (same component name, new import source), preserving tree-shaking (no barrel re-export).
- **Footer X rebrand**: the social link already targets `x.com/sipprotocol`, so the removed Twitter bird is replaced with the current **X logo** — icon, `aria-label`, and nav label all updated to "X".

## Lockfile note (please read)
A full `pnpm install` after the bump re-resolves an **unrelated** `@here-wallet/core` borsh peer (`2.0.0 → 0.7.0`, an incompatible old API) and adds `libc` metadata — latent pnpm-10.33 churn unrelated to lucide. Since `lucide-react` is dependency-free, the lucide entries were **spliced onto the existing lockfile** instead, leaving the NEAR/Here-wallet runtime untouched. The lockfile diff is therefore **lucide-only** and `pnpm install --frozen-lockfile` passes clean.

## Verification
- `pnpm typecheck` → 0 errors
- `pnpm lint` → clean (`--max-warnings 0`)
- `pnpm build` → success (all routes static-prerendered)
- `pnpm test:run` → 157/157 passing
- Visual: GitHub octocat (header "Star", repo list, footer) and X logo (footer social row + "X" nav label) render correctly in a styled dev build

## Out of scope
`founder-profile.tsx` has its own inline brand SVGs (not lucide) and still says "Twitter" — a separate branding-consistency follow-up, not part of this dep migration.